### PR TITLE
Ignore additional generated and virtual environment files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ ImproTronIcons.py
 *.pro.user*
 CMakeLists.txt.user*
 ui_*.py
+pysidedeploy.spec
 
 # xemacs temporary files
 *.flc
@@ -80,3 +81,7 @@ ui_*.py
 *.dll
 *.exe
 
+# venv
+pyvenv.cfg
+bin/**
+lib/**


### PR DESCRIPTION
Coming in new to this repo and application I believe I am finding some very minor tasks that improve it.

Once the build/compile instructions were followed, and a Python virtual environment was created for the project, there were several thousand added files waiting to be committed from those operations. Adding those to the gitignore seemed like a good thing to do.

- pysidedeploy.spec is generated when building for deployment. See https://doc.qt.io/qtforpython-6.5/deployment/deployment-pyside6-deploy.html
- Python's virtual environment adds the bin and lib directories as well as its pyvenv.cfg, all relevant only to the developer's environment.