### PR TITLE
Ignore additional generated and virtual environment files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ ImproTronIcons.py
 *.pro.user*
 CMakeLists.txt.user*
 ui_*.py
+pysidedeploy.spec
 
 # xemacs temporary files
 *.flc
@@ -80,3 +81,7 @@ ui_*.py
 *.dll
 *.exe
 
+# venv
+pyvenv.cfg
+bin/**
+lib/**


### PR DESCRIPTION
* pysidedeploy.spec is generated when building for deployment and should be ignored by scm. See https://doc.qt.io/qtforpython-6.5/deployment/deployment-pyside6-deploy.html
* Python's virtual environment adds the bin and lib directories as well as its pyvenv.cfg, all relevant only to the developer's environment.